### PR TITLE
Handle Array/Object Conversion

### DIFF
--- a/src/JsonPointer.php
+++ b/src/JsonPointer.php
@@ -108,6 +108,9 @@ class JsonPointer
                     } else {
                         throw new Exception('Non-existent path item: ' . $key);
                     }
+                } elseif ([] === $ref && false === $intKey && '-' !== $key) {
+                    $ref = new \stdClass();
+                    $ref = &$ref->{$key};
                 } else {
                     if ($recursively && $ref === null) $ref = array();
                     if ('-' === $key) {

--- a/tests/src/Issues/Issue9Test.php
+++ b/tests/src/Issues/Issue9Test.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Swaggest\JsonDiff\Tests\Issues;
+
+use Swaggest\JsonDiff\JsonDiff;
+
+/**
+ * @see https://github.com/swaggest/json-diff/issues/9
+ */
+class Issue9Test extends \PHPUnit_Framework_TestCase
+{
+    public function testPatchApply()
+    {
+        $old = json_decode(json_encode(["emptyObject" => []]));
+        $new = json_decode(json_encode(["emptyObject" => ["notEmpty"=>"value"]]));
+        $diff = new JsonDiff($old, $new);
+        $patch = $diff->getPatch();
+        $this->assertNotEquals($new, $old);
+        $patch->apply($old);
+        $this->assertEquals($new, $old);
+    }
+} 


### PR DESCRIPTION
This commit allows us to patch from an empty "array" into an object.

Without this commit:
```
$old = ["emptyObject" => []];
$new = ["emptyObject" => ["notEmpty"=>"value"]];
$diff = new \Swaggest\JsonDiff\JsonDiff(json_decode(json_encode($old)),
json_decode(json_encode($new)));
$patch = $diff->getPatch();

$test = json_decode(json_encode($old));
$patch->apply($test);
```
fails