### PR TITLE
Added getDiffCnt method to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,9 @@ Options can be combined, e.g. `JsonDiff::REARRANGE_ARRAYS + JsonDiff::STOP_ON_DI
 
 On created object you have several handy methods.
 
+#### `getDiffCnt`
+Returns total number of differences
+
 #### `getPatch`
 Returns [`JsonPatch`](#jsonpatch) of difference
 


### PR DESCRIPTION
I needed to use the `getDiffCnt` method in my code but didn't initially realise it was available as it was missing from the readme.