### PR TITLE
Throw different exception for failed test op

### DIFF
--- a/src/JsonPatch.php
+++ b/src/JsonPatch.php
@@ -170,7 +170,7 @@ class JsonPatch implements \JsonSerializable
                         $diff = new JsonDiff($operation->value, $value,
                             JsonDiff::STOP_ON_DIFF);
                         if ($diff->getDiffCnt() !== 0) {
-                            throw new Exception('Test operation ' . json_encode($operation, JSON_UNESCAPED_SLASHES)
+                            throw new PatchTestOperationFailedException('Test operation ' . json_encode($operation, JSON_UNESCAPED_SLASHES)
                                 . ' failed: ' . json_encode($value));
                         }
                         break;

--- a/src/PatchTestOperationFailedException.php
+++ b/src/PatchTestOperationFailedException.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Swaggest\JsonDiff;
+
+
+class PatchTestOperationFailedException extends Exception
+{
+}

--- a/tests/src/JsonPatchTest.php
+++ b/tests/src/JsonPatchTest.php
@@ -5,6 +5,7 @@ namespace Swaggest\JsonDiff\Tests;
 use Swaggest\JsonDiff\Exception;
 use Swaggest\JsonDiff\JsonDiff;
 use Swaggest\JsonDiff\JsonPatch;
+use Swaggest\JsonDiff\PatchTestOperationFailedException;
 
 class JsonPatchTest extends \PHPUnit_Framework_TestCase
 {
@@ -140,6 +141,15 @@ JSON;
         $p->op(new JsonPatch\Add('/some', 22));
         $p->apply($data);
         $this->assertEquals((object)array('some' => 22), $data);
+    }
+
+    public function testTestOperationFailed()
+    {
+        $data = array('abc' => 'xyz');
+        $p = new JsonPatch();
+        $p->op(new JsonPatch\Test('/abc', 'def'));
+        $errors = $p->apply($data, false);
+        $this->assertInstanceOf(PatchTestOperationFailedException::class, $errors[0]);
     }
 
 }


### PR DESCRIPTION
Hi! :wave: 

This PR adds a new exception type, which allows users of this library to distinguish between `apply()` errors due to the patch not being applicable and errors due to failed test operations.

Our (@wmde's) use case is a REST API with a PATCH endpoint which should have a different response for these two types of errors. We would like to do the following (simplified):

```php
try {
	$patch->apply( $original );
} catch ( PatchTestOperationFailedException $e ) {
	// response saying the provided test operation failed
} catch ( Exception $e ) {
	// response saying the patch cannot be applied to the resource
}
```

As far as I can tell the only way to distinguish the two at the moment is by the exception message, which is a bit awkward to handle in code.