### PR TITLE
Update PHP version in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ docker-test-new:
 	@docker run -v $$PWD:/app -w /app --rm php:8.1.0RC1-zts-buster php vendor/bin/phpunit --configuration phpunit.xml
 
 docker-test-old:
-	@docker run -v $$PWD:/app -w /app --rm php:5.4-cli php vendor/bin/phpunit --configuration phpunit.xml
+	@docker run -v $$PWD:/app -w /app --rm php:5.6-cli php vendor/bin/phpunit --configuration phpunit.xml
 
 test:
 	@php vendor/bin/phpunit --configuration phpunit.xml


### PR DESCRIPTION
Following commit 5ee88cc, PHP 5.4 and 5.5 are no longer tested. This change reflects supported PHP versions in the docker-test-old make command.