### PR TITLE
Improve JsonPatch exceptions

### DIFF
--- a/src/JsonPatch.php
+++ b/src/JsonPatch.php
@@ -174,8 +174,7 @@ class JsonPatch implements \JsonSerializable
                         $diff = new JsonDiff($operation->value, $value,
                             JsonDiff::STOP_ON_DIFF);
                         if ($diff->getDiffCnt() !== 0) {
-                            throw new PatchTestOperationFailedException('Test operation ' . json_encode($operation, JSON_UNESCAPED_SLASHES)
-                                . ' failed: ' . json_encode($value));
+                            throw new PatchTestOperationFailedException($operation, $value);
                         }
                         break;
                 }

--- a/src/JsonPatch.php
+++ b/src/JsonPatch.php
@@ -60,11 +60,15 @@ class JsonPatch implements \JsonSerializable
                 $operation = (object)$operation;
             }
 
+            if (!is_object($operation)) {
+                throw new Exception( 'Invalid patch operation - should be a JSON object' );
+            }
+
             if (!isset($operation->op)) {
-                throw new Exception('Missing "op" in operation data');
+                throw new MissingFieldException('op', $operation);
             }
             if (!isset($operation->path)) {
-                throw new Exception('Missing "path" in operation data');
+                throw new MissingFieldException('path', $operation);
             }
 
             $op = null;
@@ -88,18 +92,18 @@ class JsonPatch implements \JsonSerializable
                     $op = new Test();
                     break;
                 default:
-                    throw new Exception('Unknown "op": ' . $operation->op);
+                    throw new UnknownOperationException($operation);
             }
             $op->path = $operation->path;
             if ($op instanceof OpPathValue) {
                 if (property_exists($operation, 'value')) {
                     $op->value = $operation->value;
                 } else {
-                    throw new Exception('Missing "value" in operation data');
+                    throw new MissingFieldException('value', $operation);
                 }
             } elseif ($op instanceof OpPathFrom) {
                 if (!isset($operation->from)) {
-                    throw new Exception('Missing "from" in operation data');
+                    throw new MissingFieldException('from', $operation);
                 }
                 $op->from = $operation->from;
             }

--- a/src/JsonPointer.php
+++ b/src/JsonPointer.php
@@ -66,7 +66,7 @@ class JsonPointer
             return self::splitPathURIFragment($pathItems);
         } else {
             if ($first !== '') {
-                throw new Exception('Path must start with "/": ' . $path);
+                throw new JsonPointerException('Path must start with "/": ' . $path);
             }
             return self::splitPathJsonString($pathItems);
         }
@@ -105,7 +105,7 @@ class JsonPointer
         while (null !== $key = array_shift($pathItems)) {
             if ($ref instanceof \stdClass || is_object($ref)) {
                 if (PHP_VERSION_ID < 70100 && '' === $key) {
-                    throw new Exception('Empty property name is not supported by PHP <7.1',
+                    throw new JsonPointerException('Empty property name is not supported by PHP <7.1',
                         Exception::EMPTY_PROPERTY_NAME_UNSUPPORTED);
                 }
 
@@ -113,7 +113,7 @@ class JsonPointer
                     $ref = &$ref->$key;
                 } else {
                     if (!isset($ref->$key) && count($pathItems)) {
-                        throw new Exception('Non-existent path item: ' . $key);
+                        throw new JsonPointerException('Non-existent path item: ' . $key);
                     } else {
                         $ref = &$ref->$key;
                     }
@@ -126,7 +126,7 @@ class JsonPointer
                         $ref = new \stdClass();
                         $ref = &$ref->{$key};
                     } else {
-                        throw new Exception('Non-existent path item: ' . $key);
+                        throw new JsonPointerException('Non-existent path item: ' . $key);
                     }
                 } elseif ([] === $ref && 0 === ($flags & self::STRICT_MODE) && false === $intKey && '-' !== $key) {
                     $ref = new \stdClass();
@@ -138,7 +138,7 @@ class JsonPointer
                     } else {
                         if (false === $intKey) {
                             if (0 === ($flags & self::TOLERATE_ASSOCIATIVE_ARRAYS)) {
-                                throw new Exception('Invalid key for array operation');
+                                throw new JsonPointerException('Invalid key for array operation');
                             }
                             $ref = &$ref[$key];
                             continue;
@@ -148,9 +148,9 @@ class JsonPointer
                         }
                         if (0 === ($flags & self::TOLERATE_ASSOCIATIVE_ARRAYS)) {
                             if ($intKey > count($ref) && 0 === ($flags & self::RECURSIVE_KEY_CREATION)) {
-                                throw new Exception('Index is greater than number of items in array');
+                                throw new JsonPointerException('Index is greater than number of items in array');
                             } elseif ($intKey < 0) {
-                                throw new Exception('Negative index');
+                                throw new JsonPointerException('Negative index');
                             }
                         }
 
@@ -203,7 +203,7 @@ class JsonPointer
         while (null !== $key = array_shift($pathItems)) {
             if ($ref instanceof \stdClass) {
                 if (PHP_VERSION_ID < 70100 && '' === $key) {
-                    throw new Exception('Empty property name is not supported by PHP <7.1',
+                    throw new JsonPointerException('Empty property name is not supported by PHP <7.1',
                         Exception::EMPTY_PROPERTY_NAME_UNSUPPORTED);
                 }
 
@@ -211,22 +211,22 @@ class JsonPointer
                 if (self::arrayKeyExists($key, $vars)) {
                     $ref = self::arrayGet($key, $vars);
                 } else {
-                    throw new Exception('Key not found: ' . $key);
+                    throw new JsonPointerException('Key not found: ' . $key);
                 }
             } elseif (is_array($ref)) {
                 if (self::arrayKeyExists($key, $ref)) {
                     $ref = $ref[$key];
                 } else {
-                    throw new Exception('Key not found: ' . $key);
+                    throw new JsonPointerException('Key not found: ' . $key);
                 }
             } elseif (is_object($ref)) {
                 if (isset($ref->$key)) {
                     $ref = $ref->$key;
                 } else {
-                    throw new Exception('Key not found: ' . $key);
+                    throw new JsonPointerException('Key not found: ' . $key);
                 }
             } else {
-                throw new Exception('Key not found: ' . $key);
+                throw new JsonPointerException('Key not found: ' . $key);
             }
         }
         return $ref;
@@ -260,19 +260,19 @@ class JsonPointer
                 if (property_exists($ref, $key)) {
                     $ref = &$ref->$key;
                 } else {
-                    throw new Exception('Key not found: ' . $key);
+                    throw new JsonPointerException('Key not found: ' . $key);
                 }
             } elseif (is_object($ref)) {
                 if (isset($ref->$key)) {
                     $ref = &$ref->$key;
                 } else {
-                    throw new Exception('Key not found: ' . $key);
+                    throw new JsonPointerException('Key not found: ' . $key);
                 }
             } else {
                 if (array_key_exists($key, $ref)) {
                     $ref = &$ref[$key];
                 } else {
-                    throw new Exception('Key not found: ' . $key);
+                    throw new JsonPointerException('Key not found: ' . $key);
                 }
             }
         }

--- a/src/JsonPointerException.php
+++ b/src/JsonPointerException.php
@@ -1,0 +1,5 @@
+<?php
+
+namespace Swaggest\JsonDiff;
+
+class JsonPointerException extends Exception {}

--- a/src/MissingFieldException.php
+++ b/src/MissingFieldException.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Swaggest\JsonDiff;
+
+use Throwable;
+
+class MissingFieldException extends Exception
+{
+    /** @var string */
+    private $missingField;
+    /** @var object */
+    private $operation;
+
+    /**
+     * @param string $missingField
+     * @param object $operation
+     * @param int $code
+     * @param Throwable|null $previous
+     */
+    public function __construct(
+        $missingField,
+        $operation,
+        $code = 0,
+        Throwable $previous = null
+    )
+    {
+        parent::__construct('Missing "' . $missingField . '" in operation data', $code, $previous);
+        $this->missingField = $missingField;
+        $this->operation = $operation;
+    }
+
+    /**
+     * @return string
+     */
+    public function getMissingField()
+    {
+        return $this->missingField;
+    }
+
+    /**
+     * @return object
+     */
+    public function getOperation()
+    {
+        return $this->operation;
+    }
+}

--- a/src/PatchTestOperationFailedException.php
+++ b/src/PatchTestOperationFailedException.php
@@ -3,6 +3,47 @@
 namespace Swaggest\JsonDiff;
 
 
+use Throwable;
+
 class PatchTestOperationFailedException extends Exception
 {
+    /** @var object */
+    private $operation;
+    /** @var string */
+    private $actualValue;
+
+    /**
+     * @param object $operation
+     * @param string $actualValue
+     * @param int $code
+     * @param Throwable|null $previous
+     */
+    public function __construct(
+        $operation,
+        $actualValue,
+        $code = 0,
+        Throwable $previous = null
+    )
+    {
+        parent::__construct('Test operation ' . json_encode($operation, JSON_UNESCAPED_SLASHES)
+            . ' failed: ' . json_encode($actualValue), $code, $previous);
+        $this->operation = $operation;
+        $this->actualValue = $actualValue;
+    }
+
+    /**
+     * @return object
+     */
+    public function getOperation()
+    {
+        return $this->operation;
+    }
+
+    /**
+     * @return string
+     */
+    public function getActualValue()
+    {
+        return $this->actualValue;
+    }
 }

--- a/src/PathException.php
+++ b/src/PathException.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Swaggest\JsonDiff;
+
+
+use Throwable;
+
+class PathException extends Exception
+{
+    /** @var object */
+    private $operation;
+
+    /** @var string */
+    private $field;
+
+    /**
+     * @param string $message
+     * @param object $operation
+     * @param string $field
+     * @param int $code
+     * @param Throwable|null $previous
+     */
+    public function __construct(
+        $message,
+        $operation,
+        $field,
+        $code = 0,
+        Throwable $previous = null
+    )
+    {
+        parent::__construct($message, $code, $previous);
+        $this->operation = $operation;
+        $this->field = $field;
+    }
+
+    /**
+     * @return object
+     */
+    public function getOperation()
+    {
+        return $this->operation;
+    }
+
+    /**
+     * @return string
+     */
+    public function getField()
+    {
+        return $this->field;
+    }
+}

--- a/src/UnknownOperationException.php
+++ b/src/UnknownOperationException.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Swaggest\JsonDiff;
+
+
+use Throwable;
+
+class UnknownOperationException extends Exception
+{
+    /** @var object */
+    private $operation;
+
+    /**
+     * @param object $operation
+     * @param int $code
+     * @param Throwable|null $previous
+     */
+    public function __construct(
+        $operation,
+        $code = 0,
+        Throwable $previous = null
+    )
+    {
+        // @phpstan-ignore-next-line MissingFieldOperation will be thrown if op is not set
+        parent::__construct('Unknown "op": ' . $operation->op, $code, $previous);
+        $this->operation = $operation;
+    }
+
+    /**
+     * @return object
+     */
+    public function getOperation()
+    {
+        return $this->operation;
+    }
+}

--- a/tests/src/JsonPatchTest.php
+++ b/tests/src/JsonPatchTest.php
@@ -162,11 +162,16 @@ JSON;
 
     public function testTestOperationFailed()
     {
-        $data = array('abc' => 'xyz');
+        $actualValue = 'xyz';
+        $data = array('abc' => $actualValue);
+        $operation = new JsonPatch\Test('/abc', 'def');
+
         $p = new JsonPatch();
-        $p->op(new JsonPatch\Test('/abc', 'def'));
-        $errors = $p->apply($data, false);
-        $this->assertInstanceOf(PatchTestOperationFailedException::class, $errors[0]);
+        $p->op($operation);
+        $testError = $p->apply($data, false)[0];
+        $this->assertInstanceOf(PatchTestOperationFailedException::class, $testError);
+        $this->assertSame($operation, $testError->getOperation());
+        $this->assertSame($actualValue, $testError->getActualValue());
     }
 
 }

--- a/tests/src/JsonPatchTest.php
+++ b/tests/src/JsonPatchTest.php
@@ -5,7 +5,9 @@ namespace Swaggest\JsonDiff\Tests;
 use Swaggest\JsonDiff\Exception;
 use Swaggest\JsonDiff\JsonDiff;
 use Swaggest\JsonDiff\JsonPatch;
+use Swaggest\JsonDiff\MissingFieldException;
 use Swaggest\JsonDiff\PatchTestOperationFailedException;
+use Swaggest\JsonDiff\UnknownOperationException;
 
 class JsonPatchTest extends \PHPUnit_Framework_TestCase
 {
@@ -75,7 +77,7 @@ JSON;
 
     public function testMissingOp()
     {
-        $this->setExpectedException(get_class(new Exception()), 'Missing "op" in operation data');
+        $this->setExpectedException(MissingFieldException::class, 'Missing "op" in operation data');
         JsonPatch::import(array((object)array('path' => '/123')));
     }
 
@@ -87,7 +89,7 @@ JSON;
 
     public function testInvalidOp()
     {
-        $this->setExpectedException(get_class(new Exception()), 'Unknown "op": wat');
+        $this->setExpectedException(UnknownOperationException::class, 'Unknown "op": wat');
         JsonPatch::import(array((object)array('op' => 'wat', 'path' => '/123')));
     }
 

--- a/tests/src/JsonPatchTest.php
+++ b/tests/src/JsonPatchTest.php
@@ -5,8 +5,10 @@ namespace Swaggest\JsonDiff\Tests;
 use Swaggest\JsonDiff\Exception;
 use Swaggest\JsonDiff\JsonDiff;
 use Swaggest\JsonDiff\JsonPatch;
+use Swaggest\JsonDiff\JsonPatch\OpPath;
 use Swaggest\JsonDiff\MissingFieldException;
 use Swaggest\JsonDiff\PatchTestOperationFailedException;
+use Swaggest\JsonDiff\PathException;
 use Swaggest\JsonDiff\UnknownOperationException;
 
 class JsonPatchTest extends \PHPUnit_Framework_TestCase
@@ -174,4 +176,88 @@ JSON;
         $this->assertSame($actualValue, $testError->getActualValue());
     }
 
+    public function testPathExceptionContinueOnError()
+    {
+        $actualValue = 'xyz';
+        $data = array('abc' => $actualValue);
+        $patch = new JsonPatch();
+
+        $operation1 = new JsonPatch\Test('/abc', 'def');
+        $patch->op($operation1);
+
+        $operation2 = new JsonPatch\Move('/target', '/source');
+        $patch->op($operation2);
+
+        $errors = $patch->apply($data, false);
+
+        $this->assertInstanceOf(PatchTestOperationFailedException::class, $errors[0]);
+        $this->assertSame($operation1, $errors[0]->getOperation());
+
+        $this->assertInstanceOf(PathException::class, $errors[1]);
+        $this->assertSame($operation2, $errors[1]->getOperation());
+        $this->assertSame('from', $errors[1]->getField());
+    }
+
+    public function pathExceptionProvider() {
+        return [
+            'splitPath_path' => [
+                new JsonPatch\Copy('invalid/path', '/valid/from'),
+                'Path must start with "/": invalid/path',
+                'path'
+            ],
+            'splitPath_from' => [
+                new JsonPatch\Copy('/valid/path', 'invalid/from'),
+                'Path must start with "/": invalid/from',
+                'from'
+            ],
+            'add' => [
+                new JsonPatch\Add('/some/path', 22),
+                'Non-existent path item: some',
+                'path'
+            ],
+            'get_from' => [
+                new JsonPatch\Copy('/target', '/source'),
+                'Key not found: source',
+                'from'
+            ],
+            'get_path' => [
+                new JsonPatch\Replace('/some/path', 23),
+                'Key not found: some',
+                'path'
+            ],
+            'remove_from' => [
+                new JsonPatch\Move('/target', '/source'),
+                'Key not found: source',
+                'from'
+            ],
+            'remove_path' => [
+                new JsonPatch\Remove('/some/path'),
+                'Key not found: some',
+                'path'
+            ]
+        ];
+    }
+
+    /**
+     * @param OpPath $operation
+     * @param string $expectedMessage
+     * @param string $expectedField
+     *
+     * @dataProvider pathExceptionProvider
+     */
+    public function testPathException(OpPath $operation, $expectedMessage, $expectedField) {
+        $data = new \stdClass();
+        $patch = new JsonPatch();
+
+        $patch->op($operation);
+
+        try {
+            $patch->apply($data );
+            $this->fail('PathException expected');
+        } catch (Exception $ex) {
+            $this->assertInstanceOf(PathException::class, $ex);
+            $this->assertEquals($expectedMessage, $ex->getMessage());
+            $this->assertEquals($expectedField, $ex->getField());
+        }
+    }
 }

--- a/tests/src/JsonPatchTest.php
+++ b/tests/src/JsonPatchTest.php
@@ -77,8 +77,16 @@ JSON;
 
     public function testMissingOp()
     {
-        $this->setExpectedException(MissingFieldException::class, 'Missing "op" in operation data');
-        JsonPatch::import(array((object)array('path' => '/123')));
+		$operation = (object)array('path' => '/123');
+		try {
+			JsonPatch::import(array($operation));
+			$this->fail('Expected exception was not thrown');
+		} catch (Exception $exception) {
+			$this->assertInstanceOf(MissingFieldException::class, $exception);
+			$this->assertSame('Missing "op" in operation data', $exception->getMessage());
+			$this->assertSame('op', $exception->getMissingField());
+			$this->assertSame($operation, $exception->getOperation());
+		}
     }
 
     public function testMissingPath()
@@ -89,8 +97,15 @@ JSON;
 
     public function testInvalidOp()
     {
-        $this->setExpectedException(UnknownOperationException::class, 'Unknown "op": wat');
-        JsonPatch::import(array((object)array('op' => 'wat', 'path' => '/123')));
+		$operation = (object)array('op' => 'wat', 'path' => '/123');
+		try {
+			JsonPatch::import(array($operation));
+			$this->fail('Expected exception was not thrown');
+		} catch (Exception $exception) {
+			$this->assertInstanceOf(UnknownOperationException::class, $exception);
+			$this->assertSame('Unknown "op": wat', $exception->getMessage());
+			$this->assertSame($operation, $exception->getOperation());
+		}
     }
 
     public function testMissingFrom()

--- a/tests/src/JsonPointerTest.php
+++ b/tests/src/JsonPointerTest.php
@@ -5,6 +5,7 @@ namespace Swaggest\JsonDiff\Tests;
 
 use Swaggest\JsonDiff\Exception;
 use Swaggest\JsonDiff\JsonPointer;
+use Swaggest\JsonDiff\JsonPointerException;
 
 class JsonPointerTest extends \PHPUnit_Framework_TestCase
 {
@@ -30,7 +31,7 @@ class JsonPointerTest extends \PHPUnit_Framework_TestCase
 
         try {
             $this->assertSame('null', json_encode(JsonPointer::get($json, JsonPointer::splitPath('/l1/l2/non-existent'))));
-        } catch (Exception $exception) {
+        } catch (JsonPointerException $exception) {
             $this->assertSame('Key not found: non-existent', $exception->getMessage());
         }
 
@@ -89,7 +90,7 @@ class JsonPointerTest extends \PHPUnit_Framework_TestCase
         try {
             JsonPointer::get($s, ['one', 'two']);
             $this->fail('Exception expected');
-        } catch (Exception $e) {
+        } catch (JsonPointerException $e) {
             $this->assertEquals('Key not found: two', $e->getMessage());
         }
         $this->assertEquals(null, $s->one->two);


### PR DESCRIPTION
Hi again :wave: 

@Silvan-WMDE, @outdooracorn and I worked on the aforementioned improvements to `JsonPatch` errors. Here is what we did:
* `JsonPatch::import()` now throws a `MissingFieldException` in case of a missing field. The exception contains the name of the missing field and the operation.
* `JsonPatch::import()` now throws a `UnknownOperationException` in case of an unknown operation type. The exception contains the operation.
* `PatchTestOperationFailedException` now contains the failed operation and the value that caused the test operation to fail.
* `JsonPatch::apply()` now throws a `PathException` in case anything is wrong with the path in a "path" or "from" field of an operation. The exception contains the name of the problematic field ("path" or "from") and the operation.
* `JsonPointer` now always throws `JsonPointerException` instead of a generic `Exception`. 

This last point isn't really something we planned on doing, but it helped us in our implementation of the `PathException` case above. We also considered an alternative approach in https://github.com/wmde/json-diff/pull/4/files that didn't require the introduction of a `JsonPointerException`. We'd be curious to hear your thoughts on it, or alternative ideas!

The changes are fairly well split up into commits. Let me know if that works, or if you'd rather have the changes submitted individually or sliced differently.

Thanks! :)

Fixes #53.