### PR TITLE
Throw exception when field type is incorrect

### DIFF
--- a/src/InvalidFieldTypeException.php
+++ b/src/InvalidFieldTypeException.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Swaggest\JsonDiff;
+
+
+use Swaggest\JsonDiff\JsonPatch\OpPath;
+use Throwable;
+
+class InvalidFieldTypeException extends Exception
+{
+    /** @var string */
+    private $field;
+    /** @var string */
+    private $expectedType;
+    /** @var OpPath|object */
+    private $operation;
+
+    /**
+     * @param string $field
+     * @param string $expectedType
+     * @param OpPath|object $operation
+     * @param int $code
+     * @param Throwable|null $previous
+     */
+    public function __construct(
+        $field,
+        $expectedType,
+        $operation,
+        $code = 0,
+        Throwable $previous = null
+    )
+    {
+        parent::__construct(
+            'Invalid field type - "' . $field . '" should be of type: ' . $expectedType,
+            $code,
+            $previous
+        );
+        $this->field = $field;
+        $this->expectedType = $expectedType;
+        $this->operation = $operation;
+    }
+
+    /**
+     * @return string
+     */
+    public function getField()
+    {
+        return $this->field;
+    }
+
+    /**
+     * @return string
+     */
+    public function getExpectedType()
+    {
+        return $this->expectedType;
+    }
+
+    /**
+     * @return OpPath|object
+     */
+    public function getOperation()
+    {
+        return $this->operation;
+    }
+}

--- a/src/JsonPatch.php
+++ b/src/JsonPatch.php
@@ -59,7 +59,6 @@ class JsonPatch implements \JsonSerializable
             if (is_array($operation)) {
                 $operation = (object)$operation;
             }
-
             if (!is_object($operation)) {
                 throw new Exception('Invalid patch operation - should be a JSON object');
             }
@@ -69,6 +68,13 @@ class JsonPatch implements \JsonSerializable
             }
             if (!isset($operation->path)) {
                 throw new MissingFieldException('path', $operation);
+            }
+
+            if (!is_string($operation->op)) {
+                throw new InvalidFieldTypeException('op', 'string', $operation);
+            }
+            if (!is_string($operation->path)) {
+                throw new InvalidFieldTypeException('path', 'string', $operation);
             }
 
             $op = null;
@@ -104,6 +110,8 @@ class JsonPatch implements \JsonSerializable
             } elseif ($op instanceof OpPathFrom) {
                 if (!isset($operation->from)) {
                     throw new MissingFieldException('from', $operation);
+                } elseif (!is_string($operation->from)) {
+                    throw new InvalidFieldTypeException('from', 'string', $operation);
                 }
                 $op->from = $operation->from;
             }

--- a/tests/src/JsonPatchTest.php
+++ b/tests/src/JsonPatchTest.php
@@ -110,6 +110,45 @@ JSON;
 		}
     }
 
+    /**
+     * @dataProvider provideInvalidFieldType
+     *
+     * @param object $operation
+     * @param string $expectedException
+     * @param string $expectedMessage
+     */
+    public function testInvalidFieldType($operation, $expectedException, $expectedMessage)
+    {
+        try {
+            JsonPatch::import(array($operation));
+            $this->fail('Expected exception was not thrown');
+        } catch (Exception $exception) {
+            $this->assertInstanceOf($expectedException, $exception);
+            $this->assertSame($expectedMessage, $exception->getMessage());
+        }
+    }
+
+    public function provideInvalidFieldType()
+    {
+        return [
+            '"op" invalid type' => [
+                (object)array('op' => array('foo' => 'bar'), 'path' => '/123', 'value' => 'test'),
+                Exception::class,
+                'Invalid field type - "op" should be of type: string'
+            ],
+            '"path" invalid type' => [
+                (object)array('op' => 'add', 'path' => array('foo' => 'bar'), 'value' => 'test'),
+                Exception::class,
+                'Invalid field type - "path" should be of type: string'
+            ],
+            '"from" invalid type' => [
+                (object)array('op' => 'move', 'path' => '/123', 'from' => array('foo' => 'bar')),
+                Exception::class,
+                'Invalid field type - "from" should be of type: string'
+            ]
+        ];
+    }
+
     public function testMissingFrom()
     {
         $this->setExpectedException(get_class(new Exception()), 'Missing "from" in operation data');

--- a/tests/src/JsonPatchTest.php
+++ b/tests/src/JsonPatchTest.php
@@ -3,6 +3,7 @@
 namespace Swaggest\JsonDiff\Tests;
 
 use Swaggest\JsonDiff\Exception;
+use Swaggest\JsonDiff\InvalidFieldTypeException;
 use Swaggest\JsonDiff\JsonDiff;
 use Swaggest\JsonDiff\JsonPatch;
 use Swaggest\JsonDiff\JsonPatch\OpPath;
@@ -114,17 +115,21 @@ JSON;
      * @dataProvider provideInvalidFieldType
      *
      * @param object $operation
-     * @param string $expectedException
      * @param string $expectedMessage
+     * @param string $expectedField
+     * @param string $expectedType
      */
-    public function testInvalidFieldType($operation, $expectedException, $expectedMessage)
+    public function testInvalidFieldType($operation, $expectedMessage, $expectedField, $expectedType)
     {
         try {
             JsonPatch::import(array($operation));
             $this->fail('Expected exception was not thrown');
         } catch (Exception $exception) {
-            $this->assertInstanceOf($expectedException, $exception);
+            $this->assertInstanceOf(InvalidFieldTypeException::class, $exception);
             $this->assertSame($expectedMessage, $exception->getMessage());
+            $this->assertSame($expectedField, $exception->getField());
+            $this->assertSame($expectedType, $exception->getExpectedType());
+            $this->assertSame($operation, $exception->getOperation());
         }
     }
 
@@ -133,18 +138,21 @@ JSON;
         return [
             '"op" invalid type' => [
                 (object)array('op' => array('foo' => 'bar'), 'path' => '/123', 'value' => 'test'),
-                Exception::class,
-                'Invalid field type - "op" should be of type: string'
+                'Invalid field type - "op" should be of type: string',
+                'op',
+                'string'
             ],
             '"path" invalid type' => [
                 (object)array('op' => 'add', 'path' => array('foo' => 'bar'), 'value' => 'test'),
-                Exception::class,
-                'Invalid field type - "path" should be of type: string'
+                'Invalid field type - "path" should be of type: string',
+                'path',
+                'string'
             ],
             '"from" invalid type' => [
                 (object)array('op' => 'move', 'path' => '/123', 'from' => array('foo' => 'bar')),
-                Exception::class,
-                'Invalid field type - "from" should be of type: string'
+                'Invalid field type - "from" should be of type: string',
+                'from',
+                'string'
             ]
         ];
     }


### PR DESCRIPTION
Another late addition to our improvements on error handling (#53).

Fixes the following edge cases:
- if the `"op"` field is boolean `true`, it is interpreted as an `"add"` operation instead of throwing an exception. This is due to `true` always matching the first [switch case] (`Add::OP`).
- if the `"op"` field is an Array (list) or Object, it results in a "PHP Notice Array/Object to string conversion" in the [`UnknownOperationException`]
- if the `"path"` or `"from"` fields are not a string, an exception will be thrown in `JsonPatch::apply()` rather than `JsonPatch::import()`