### PR TITLE
Prove error if "op" is boolean true

### DIFF
--- a/tests/src/JsonPatchTest.php
+++ b/tests/src/JsonPatchTest.php
@@ -137,7 +137,7 @@ JSON;
     {
         return [
             '"op" invalid type' => [
-                (object)array('op' => array('foo' => 'bar'), 'path' => '/123', 'value' => 'test'),
+                (object)array('op' => true, 'path' => '/123', 'value' => 'test'),
                 'Invalid field type - "op" should be of type: string',
                 'op',
                 'string'


### PR DESCRIPTION
The [Postpone exception throwing](https://github.com/swaggest/json-diff/commit/2b56e5d516ad5301fefd49641163736ceb0ae706) commit reverts a fix from #60.

> If the `"op"` field is boolean `true`, it is interpreted as an `"add"` operation instead of throwing an exception. This is due to `true` always matching the first [switch case](https://github.com/swaggest/json-diff/blob/02df617f4a0ed053849cc0d5a9f030c3d12f3e98/src/JsonPatch.php#L75) (`Add::OP`)

My bad for not covering it in a test!

This draft PR is to demonstrate the issue. How would you like to fix it?