### PR TITLE
fix: increment index to detect associative array

### DIFF
--- a/src/JsonPointer.php
+++ b/src/JsonPointer.php
@@ -285,7 +285,7 @@ class JsonPointer
                 if ($flags & self::TOLERATE_ASSOCIATIVE_ARRAYS) {
                     $i = 0;
                     foreach ($parent as $index => $value) {
-                        if ($i !== $index) {
+                        if ($i++ !== $index) {
                             $isAssociative = true;
                             break;
                         }


### PR DESCRIPTION
Hello,

For a patch which remove elements to non associative array, we need to reindex this array.
This line is good https://github.com/swaggest/json-diff/blob/f4e511708060ff7511a3743fab4aa484a062bcfb/src/JsonPointer.php#L297
But the condition for $isAssociative has an issue.

We need to increment $i to compare with $index, otherwise $i will always be equal to 0 for all iterations.