### PR TITLE
Fix `JsonPointer::remove()` not handling sequential arrays correctly

### DIFF
--- a/src/JsonPointer.php
+++ b/src/JsonPointer.php
@@ -289,6 +289,7 @@ class JsonPointer
                             $isAssociative = true;
                             break;
                         }
+                        $i++;
                     }
                 }
 

--- a/tests/src/JsonPointerTest.php
+++ b/tests/src/JsonPointerTest.php
@@ -96,6 +96,13 @@ class JsonPointerTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(null, $s->one->two);
     }
 
+    public function testSequentialArrayIsPreserved()
+    {
+		$json = [ 'l1' => [ 0 => 'foo', 1 => 'bar', 2 => 'baz' ] ];
+		JsonPointer::remove($json, ['l1', '1'], JsonPointer::TOLERATE_ASSOCIATIVE_ARRAYS);
+		$this->assertSame('{"l1":["foo","baz"]}', json_encode($json));
+    }
+
 }
 
 class Sample


### PR DESCRIPTION
The `JsonPointer::remove()` method doesn't correctly detect sequential vs associative arrays when the `TOLERATE_ASSOCIATIVE_ARRAYS` is enabled. This causes most sequential arrays to be converted to associative arrays.

The issue is due to the `$i` counter not being incremented in the `foreach` loop that detects whether an array is sequential or associative. 

While the counter can be incremented in the `if` statement, like in #65, I've decided to do it in the body of the `foreach` loop as I believe it to be less "clever" and easier to read. I have also added a test to prove the issue and defend against it in the future.