### PR TITLE
Add operation index to `PathException` for detailed error reporting

### DIFF
--- a/src/JsonPatch.php
+++ b/src/JsonPatch.php
@@ -151,7 +151,7 @@ class JsonPatch implements \JsonSerializable
     public function apply(&$original, $stopOnError = true)
     {
         $errors = array();
-        foreach ($this->operations as $operation) {
+        foreach ($this->operations as $opIndex => $operation) {
             try {
                 // track the current pointer field so we can use it for a potential PathException
                 $pointerField = 'path';
@@ -199,6 +199,7 @@ class JsonPatch implements \JsonSerializable
                     $pointerField,
                     $jsonPointerException->getCode()
                 );
+                $pathException->setOpIndex($opIndex);
                 if ($stopOnError) {
                     throw $pathException;
                 } else {

--- a/src/PathException.php
+++ b/src/PathException.php
@@ -14,6 +14,9 @@ class PathException extends Exception
     /** @var string */
     private $field;
 
+    /** @var int */
+    private $opIndex;
+
     /**
      * @param string $message
      * @param OpPath $operation
@@ -48,5 +51,23 @@ class PathException extends Exception
     public function getField()
     {
         return $this->field;
+    }
+
+    /**
+     * @param int $opIndex
+     * @return $this
+     */
+    public function setOpIndex($opIndex)
+    {
+        $this->opIndex = $opIndex;
+        return $this;
+    }
+
+    /**
+     * @return int
+     */
+    public function getOpIndex()
+    {
+        return $this->opIndex;
     }
 }

--- a/tests/src/JsonPatchTest.php
+++ b/tests/src/JsonPatchTest.php
@@ -229,20 +229,21 @@ JSON;
         $data = array('abc' => $actualValue);
         $patch = new JsonPatch();
 
-        $operation1 = new JsonPatch\Test('/abc', 'def');
-        $patch->op($operation1);
+        $operation0 = new JsonPatch\Test('/abc', 'def');
+        $patch->op($operation0);
 
-        $operation2 = new JsonPatch\Move('/target', '/source');
-        $patch->op($operation2);
+        $operation1 = new JsonPatch\Move('/target', '/source');
+        $patch->op($operation1);
 
         $errors = $patch->apply($data, false);
 
         $this->assertInstanceOf(PatchTestOperationFailedException::class, $errors[0]);
-        $this->assertSame($operation1, $errors[0]->getOperation());
+        $this->assertSame($operation0, $errors[0]->getOperation());
 
         $this->assertInstanceOf(PathException::class, $errors[1]);
-        $this->assertSame($operation2, $errors[1]->getOperation());
+        $this->assertSame($operation1, $errors[1]->getOperation());
         $this->assertSame('from', $errors[1]->getField());
+        $this->assertEquals(1, $errors[1]->getOpIndex());
     }
 
     public function pathExceptionProvider() {
@@ -305,6 +306,7 @@ JSON;
             $this->assertInstanceOf(PathException::class, $ex);
             $this->assertEquals($expectedMessage, $ex->getMessage());
             $this->assertEquals($expectedField, $ex->getField());
+            $this->assertEquals(0, $ex->getOpIndex()); // There is only one operation
         }
     }
 }


### PR DESCRIPTION
**The reason for this change** is to have the index for the operation in cases where two identical operations target the same resource. 

*For example,* if two identical remove operations target the same resource, the latter will fail because the first operation already removed the resource. 

By having the index, we can accurately identify and report the failing operation.
