### PR TITLE
Add PHP 8.4 support

### DIFF
--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         operating-system: [ 'ubuntu-latest' ]
-        php-versions: [ '5.6', '7.0', '7.1', '7.2', '7.3', '8.0', '8.1' ]
+        php-versions: [ '7.1', '7.2', '7.3', '8.0', '8.1', '8.2', '8.3', '8.4' ]
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,8 @@
     }
   ],
   "require": {
-    "ext-json": "*"
+    "ext-json": "*",
+    "php": ">=7.1"
   },
   "require-dev": {
     "phperf/phpunit": "4.8.37"
@@ -27,7 +28,7 @@
   },
   "config": {
     "platform": {
-      "php": "5.4.45"
+      "php": "7.1.33"
     }
   }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5713f54bfb717ba8d7193fc9e26a07d5",
+    "content-hash": "2db765b5376b2444b02b18922950f0d3",
     "packages": [],
     "packages-dev": [
         {
@@ -1138,11 +1138,12 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "ext-json": "*"
+        "ext-json": "*",
+        "php": ">=7.1"
     },
     "platform-dev": [],
     "platform-overrides": {
-        "php": "5.4.45"
+        "php": "7.1.33"
     },
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/src/InvalidFieldTypeException.php
+++ b/src/InvalidFieldTypeException.php
@@ -27,7 +27,7 @@ class InvalidFieldTypeException extends Exception
         $expectedType,
         $operation,
         $code = 0,
-        Throwable $previous = null
+        ?Throwable $previous = null
     )
     {
         parent::__construct(

--- a/src/MissingFieldException.php
+++ b/src/MissingFieldException.php
@@ -22,7 +22,7 @@ class MissingFieldException extends Exception
         $missingField,
         $operation,
         $code = 0,
-        Throwable $previous = null
+        ?Throwable $previous = null
     )
     {
         parent::__construct('Missing "' . $missingField . '" in operation data', $code, $previous);

--- a/src/PatchTestOperationFailedException.php
+++ b/src/PatchTestOperationFailedException.php
@@ -23,7 +23,7 @@ class PatchTestOperationFailedException extends Exception
         $operation,
         $actualValue,
         $code = 0,
-        Throwable $previous = null
+        ?Throwable $previous = null
     )
     {
         parent::__construct('Test operation ' . json_encode($operation, JSON_UNESCAPED_SLASHES)

--- a/src/PathException.php
+++ b/src/PathException.php
@@ -29,7 +29,7 @@ class PathException extends Exception
         $operation,
         $field,
         $code = 0,
-        Throwable $previous = null
+        ?Throwable $previous = null
     )
     {
         parent::__construct($message, $code, $previous);

--- a/src/UnknownOperationException.php
+++ b/src/UnknownOperationException.php
@@ -19,7 +19,7 @@ class UnknownOperationException extends Exception
     public function __construct(
         $operation,
         $code = 0,
-        Throwable $previous = null
+        ?Throwable $previous = null
     )
     {
         // @phpstan-ignore-next-line MissingFieldOperation will be thrown if op is not set


### PR DESCRIPTION
Implicitly nullable parameter declarations are deprecated in PHP 8.4. The proposed change is safe and is not considered by PHP as a signature change, see https://php.watch/versions/8.4/implicitly-marking-parameter-type-nullable-deprecated

Unfortunately, this syntax is compatible only with PHP >= 7.1. I propose to raise the minimal PHP requirement to 7.1.